### PR TITLE
Fix select parameter persistence in inspector

### DIFF
--- a/frontend/src/features/inspector/NodeInspector.tsx
+++ b/frontend/src/features/inspector/NodeInspector.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { Controller, useForm } from 'react-hook-form'
+import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -47,7 +47,7 @@ export function NodeInspector() {
   const isLoadImage = selected?.data.type === 'load_image'
   const isAnnotations = selected?.data.type === 'annotations'
 
-  const { register, handleSubmit, reset, control, setValue, formState } = useForm({
+  const { register, handleSubmit, reset, setValue, formState } = useForm({
     resolver: zodResolver(schema),
     defaultValues: selected?.data.params ?? {},
   })
@@ -213,38 +213,31 @@ export function NodeInspector() {
                 return null
               }
               if (field.type === 'select' && field.options) {
-                const options = field.options
                 return (
-                  <Controller
+                  <TextField
                     key={`${selected.id}:${field.name}`}
-                    name={field.name}
-                    control={control}
-                    render={({ field: inputField }) => (
-                      <TextField
-                        select
-                        size="small"
-                        label={field.label}
-                        helperText={field.description ?? undefined}
-                        value={String(selected.data.params[field.name] ?? '')}
-                        onChange={(event) => {
-                          const value = event.target.value
-                          inputField.onChange(value)
-                          setValue(field.name, value, {
-                            shouldDirty: true,
-                            shouldValidate: true,
-                          })
-                          updateNodeParams(selected.id, { [field.name]: value })
-                        }}
-                        onBlur={inputField.onBlur}
-                      >
-                        {options.map((option) => (
-                          <MenuItem key={option} value={option}>
-                            {option}
-                          </MenuItem>
-                        ))}
-                      </TextField>
+                    select
+                    size="small"
+                    label={field.label}
+                    helperText={field.description ?? undefined}
+                    value={String(
+                      selected.data.params[field.name] ?? field.default ?? '',
                     )}
-                  />
+                    onChange={(event) => {
+                      const value = event.target.value
+                      setValue(field.name, value, {
+                        shouldDirty: true,
+                        shouldValidate: true,
+                      })
+                      updateNodeParams(selected.id, { [field.name]: value })
+                    }}
+                  >
+                    {field.options.map((option) => (
+                      <MenuItem key={option} value={option}>
+                        {option}
+                      </MenuItem>
+                    ))}
+                  </TextField>
                 )
               }
 

--- a/frontend/src/features/inspector/NodeInspector.tsx
+++ b/frontend/src/features/inspector/NodeInspector.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useForm } from 'react-hook-form'
+import { Controller, useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -47,7 +47,7 @@ export function NodeInspector() {
   const isLoadImage = selected?.data.type === 'load_image'
   const isAnnotations = selected?.data.type === 'annotations'
 
-  const { register, handleSubmit, reset, setValue, formState } = useForm({
+  const { register, handleSubmit, reset, control, setValue, formState } = useForm({
     resolver: zodResolver(schema),
     defaultValues: selected?.data.params ?? {},
   })
@@ -213,24 +213,38 @@ export function NodeInspector() {
                 return null
               }
               if (field.type === 'select' && field.options) {
+                const options = field.options
                 return (
-                  <TextField
-                    key={field.name}
-                    select
-                    size="small"
-                    label={field.label}
-                    helperText={field.description ?? undefined}
-                    defaultValue={String(
-                      selected.data.params[field.name] ?? field.default ?? '',
+                  <Controller
+                    key={`${selected.id}:${field.name}`}
+                    name={field.name}
+                    control={control}
+                    render={({ field: inputField }) => (
+                      <TextField
+                        select
+                        size="small"
+                        label={field.label}
+                        helperText={field.description ?? undefined}
+                        value={String(selected.data.params[field.name] ?? '')}
+                        onChange={(event) => {
+                          const value = event.target.value
+                          inputField.onChange(value)
+                          setValue(field.name, value, {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          })
+                          updateNodeParams(selected.id, { [field.name]: value })
+                        }}
+                        onBlur={inputField.onBlur}
+                      >
+                        {options.map((option) => (
+                          <MenuItem key={option} value={option}>
+                            {option}
+                          </MenuItem>
+                        ))}
+                      </TextField>
                     )}
-                    {...register(field.name)}
-                  >
-                    {field.options.map((option) => (
-                      <MenuItem key={option} value={option}>
-                        {option}
-                      </MenuItem>
-                    ))}
-                  </TextField>
+                  />
                 )
               }
 
@@ -238,7 +252,7 @@ export function NodeInspector() {
 
               return (
                 <TextField
-                  key={field.name}
+                  key={`${selected.id}:${field.name}`}
                   size="small"
                   label={field.label}
                   type={field.type === 'string' ? 'text' : 'number'}


### PR DESCRIPTION
## Title

Fix inspector select parameter persistence

## Summary

Select-based node parameters could visually revert to their default value after changing them and reselecting the node. This was visible with nodes such as `Sharpen`, where changing `kernel` from `laplacian` to `unsharp` would not remain selected when the node was selected again.

The inspector used MUI `TextField select` as an uncontrolled component with `defaultValue`, while `react-hook-form` also reset the form when the selected node or node params changed. The form submission could therefore commit stale state before the controlled select value had propagated, leaving Zustand with the previous parameter value.

## Changes

- Replaced inspector select fields with `react-hook-form` `Controller`.
- Bound select values directly to `selected.data.params`.
- Updated Zustand immediately when a select value changes.
- Added node IDs to field keys to prevent DOM/form state reuse across different nodes.
- Applied node-scoped keys to other generated inspector fields as well.

## Verification

- `npm run lint`
- `npm run build`
- Verified manually in the Electron desktop app:
  - Add a `Sharpen` node.
  - Change `kernel` to `unsharp`.
  - Deselect and reselect the node.
  - Confirm `kernel` remains `unsharp`.

## Affected File

- `frontend/src/features/inspector/NodeInspector.tsx`